### PR TITLE
get event loop not running loop

### DIFF
--- a/aiorospy/src/aiorospy/action.py
+++ b/aiorospy/src/aiorospy/action.py
@@ -1,10 +1,11 @@
 import asyncio
 import logging
-import janus
-
-from actionlib import ActionServer, ActionClient, CommState, GoalStatus, SimpleActionClient, SimpleActionServer
-from actionlib_msgs.msg import GoalStatusArray
 from functools import partial
+
+from actionlib import ActionClient, ActionServer, CommState, GoalStatus, SimpleActionClient, SimpleActionServer
+from actionlib_msgs.msg import GoalStatusArray
+
+import janus
 
 from .topic import AsyncSubscriber
 
@@ -135,7 +136,7 @@ class AsyncActionClient:
 
     def __init__(self, name, action_spec, loop=None):
         self.name = name
-        self._loop = loop if loop is not None else asyncio.get_running_loop()
+        self._loop = loop if loop is not None else asyncio.get_event_loop()
         self._client = ActionClient(name, action_spec)
         self._status_sub = AsyncSubscriber(name + "/status", GoalStatusArray, loop=self._loop, queue_size=1)
 
@@ -198,7 +199,7 @@ class AsyncActionServer:
     def __init__(self, name, action_spec, coro, loop=None):
         """ Initialize an action server. Incoming goals will be processed via the speficied coroutine. """
         self.name = name
-        self._loop = loop if loop is not None else asyncio.get_running_loop()
+        self._loop = loop if loop is not None else asyncio.get_event_loop()
         self._coro = coro
         self._tasks = {}
 

--- a/aiorospy/src/aiorospy/topic.py
+++ b/aiorospy/src/aiorospy/topic.py
@@ -1,8 +1,9 @@
 import asyncio
-import janus
+from functools import partial
+
 import rospy
 
-from functools import partial
+import janus
 
 
 class AsyncSubscriber:
@@ -11,7 +12,7 @@ class AsyncSubscriber:
         self.name = name
         self._data_class = data_class
         self._queue_size = queue_size
-        self._loop = loop if loop is not None else asyncio.get_running_loop()
+        self._loop = loop if loop is not None else asyncio.get_event_loop()
 
     # TODO(pbovbel) should we check rospy.is_shutdown() instead of while True?
     async def subscribe(self):


### PR DESCRIPTION
Get running loop is used to get the loop that is currently running the coroutine/callback that `get_running_loop` is called from. This isn't the case here as these are called in `__init__` and are likely called outside of the event loop.

Using `get_event_loop` is a convenient way to not mandate that the user passes an event loop everywhere (but they still can if they have specific needs).