### PR TITLE
Cancel outgoing action on retry or cancel

### DIFF
--- a/aiorospy/src/aiorospy/action.py
+++ b/aiorospy/src/aiorospy/action.py
@@ -163,7 +163,12 @@ class AsyncActionClient:
             try:
                 await asyncio.wait_for(handle.reach_status(GoalStatus.PENDING), timeout=resend_timeout)
             except asyncio.TimeoutError:
+                logger.warn(f"Action goal for {self.name} was not processed within timeout, resending")
+                handle.cancel()
                 continue
+            except asyncio.CancelledError:
+                handle.cancel()
+                raise
             return handle
 
     async def wait_for_server(self):


### PR DESCRIPTION
Make sure action goal handle is properly cancelled if it is abandoned.