### PR TITLE
Implement simple action server

### DIFF
--- a/aiorospy/requirements.txt
+++ b/aiorospy/requirements.txt
@@ -1,3 +1,2 @@
-aiostream==0.3.3
 aiounittest==1.2.1
 janus==0.4.0

--- a/aiorospy/src/aiorospy/action.py
+++ b/aiorospy/src/aiorospy/action.py
@@ -232,6 +232,12 @@ class AsyncActionServer:
         if task:
             await deflector_shield(task)
 
+    async def cancel_all(self):
+        for task in self._tasks.values():
+            if not task.cancelled():
+                task.cancel()
+            await deflector_shield(other_task)
+
     def _goal_cb(self, goal_handle):
         """ Process incoming goals by spinning off a new asynchronous task to handle the callback.
         """
@@ -257,7 +263,7 @@ class AsyncActionServer:
             try:
                 await deflector_shield(other_task)
             except asyncio.CancelledError:
-                goal_handle.set_canceled(f"Goal {goal_id} was preempted")
+                goal_handle.set_canceled(f"Goal {goal_id} was preempted before starting")
                 raise
 
         rospy.logdebug(f"Starting callback for goal {goal_id}")

--- a/aiorospy/src/aiorospy/action.py
+++ b/aiorospy/src/aiorospy/action.py
@@ -236,7 +236,7 @@ class AsyncActionServer:
         for task in self._tasks.values():
             if not task.cancelled():
                 task.cancel()
-            await deflector_shield(other_task)
+            await deflector_shield(task)
 
     def _goal_cb(self, goal_handle):
         """ Process incoming goals by spinning off a new asynchronous task to handle the callback.

--- a/aiorospy/src/aiorospy/helpers.py
+++ b/aiorospy/src/aiorospy/helpers.py
@@ -122,7 +122,7 @@ async def do_while(awaitable, period, do, *args, **kwargs):
 
 
 async def log_during(awaitable, msg, period, sink=logger.info):
-    """ Convenience function to repeatedly log an line, while some task has not completed. """
+    """ Convenience function to repeatedly log a line, while some task has not completed. """
     return await do_while(awaitable, period, sink, msg)
 
 

--- a/aiorospy/tests/test_action_client.py
+++ b/aiorospy/tests/test_action_client.py
@@ -100,7 +100,7 @@ class TestActionClient(aiounittest.AsyncTestCase):
         goal_handle = await client.send_goal(TestGoal())
         await goal_handle.reach_status(GoalStatus.ACTIVE)
 
-        await goal_handle.cancel()
+        goal_handle.cancel()
         await goal_handle.reach_status(GoalStatus.PREEMPTED)
 
         client_task.cancel()

--- a/aiorospy/tests/test_action_server.py
+++ b/aiorospy/tests/test_action_server.py
@@ -11,6 +11,7 @@ from actionlib import ActionClient as SyncActionClient
 from actionlib import GoalStatus
 from actionlib.msg import TestAction, TestGoal, TestResult
 from aiorospy import AsyncActionServer
+from aiorospy.helpers import deflector_shield
 
 
 class TestActionServer(aiounittest.AsyncTestCase):
@@ -43,10 +44,7 @@ class TestActionServer(aiounittest.AsyncTestCase):
         self.assertEqual(goal_handle.get_result().result, magic_value)
 
         server_task.cancel()
-        try:
-            await server_task
-        except asyncio.CancelledError:
-            pass
+        await deflector_shield(server_task)
 
     async def test_goal_canceled_from_client(self):
         async def goal_coro(goal_handle):
@@ -73,10 +71,7 @@ class TestActionServer(aiounittest.AsyncTestCase):
         self.assertEquals(goal_handle.get_goal_status(), GoalStatus.PREEMPTED)
 
         server_task.cancel()
-        try:
-            await server_task
-        except asyncio.CancelledError:
-            pass
+        await deflector_shield(server_task)
 
     async def test_goal_canceled_from_server(self):
         queue = janus.Queue()
@@ -107,10 +102,7 @@ class TestActionServer(aiounittest.AsyncTestCase):
         self.assertEquals(goal_handle.get_goal_status(), GoalStatus.PREEMPTED)
 
         server_task.cancel()
-        try:
-            await server_task
-        except asyncio.CancelledError:
-            pass
+        await deflector_shield(server_task)
 
     async def test_goal_exception(self):
         async def goal_coro(goal_handle):
@@ -128,7 +120,7 @@ class TestActionServer(aiounittest.AsyncTestCase):
         self.assertEquals(goal_handle.get_goal_status(), GoalStatus.ABORTED)
 
         with self.assertRaises(RuntimeError):
-            await server_task
+            await deflector_shield(server_task)
 
     async def test_server_simple(self):
         event = asyncio.Event()
@@ -171,10 +163,7 @@ class TestActionServer(aiounittest.AsyncTestCase):
         self.assertEqual(last_handle.get_goal_status(), GoalStatus.SUCCEEDED)
 
         server_task.cancel()
-        try:
-            await server_task
-        except asyncio.CancelledError:
-            pass
+        await deflector_shield(server_task)
 
 
 if __name__ == '__main__':

--- a/aiorospy/tests/test_action_server.py
+++ b/aiorospy/tests/test_action_server.py
@@ -159,15 +159,15 @@ class TestActionServer(aiounittest.AsyncTestCase):
 
         handles = []
         for i in range(10):
-            handles.append(client.send_goal(TestGoal(1000000)))
+            handle = client.send_goal(TestGoal(1000000))
+            await self.wait_for_status(handle, GoalStatus.ACTIVE)
+            handles.append(handle)
 
         last_handle = client.send_goal(TestGoal(0))
         await self.wait_for_status(last_handle, GoalStatus.SUCCEEDED)
 
         for handle in handles:
-            # Due to goalspam above, a lot of the early goal handles will get stuck as PENDING and never receive a
-            # status back.
-            self.assertIn(handle.get_goal_status(), {GoalStatus.PREEMPTED, GoalStatus.PENDING})
+            self.assertEqual(handle.get_goal_status(), GoalStatus.PREEMPTED)
         self.assertEqual(last_handle.get_goal_status(), GoalStatus.SUCCEEDED)
 
         server_task.cancel()

--- a/aiorospy/tests/test_action_server.py
+++ b/aiorospy/tests/test_action_server.py
@@ -123,8 +123,8 @@ class TestActionServer(aiounittest.AsyncTestCase):
         await asyncio.get_event_loop().run_in_executor(None, client.wait_for_server)
 
         handles = []
-        for i in range(100):
-            handles.append(client.send_goal(TestGoal(i + 1)))
+        for i in range(10):
+            handles.append(client.send_goal(TestGoal(1000000)))
 
         last_handle = client.send_goal(TestGoal(0))
         await self.wait_for_status(last_handle, GoalStatus.SUCCEEDED)
@@ -169,8 +169,8 @@ class TestActionServer(aiounittest.AsyncTestCase):
         await asyncio.get_event_loop().run_in_executor(None, client.wait_for_server)
 
         handles = []
-        for i in range(100):
-            handle = client.send_goal(TestGoal(i + 1))
+        for i in range(10):
+            handle = client.send_goal(TestGoal(1000000))
             # Make sure we don't spam goals too fast. This simulates AsyncActionClient's ensure_goal.
             await self.wait_for_status(handle, GoalStatus.ACTIVE)
             handles.append(handle)

--- a/aiorospy/tests/test_aiorospy.test
+++ b/aiorospy/tests/test_aiorospy.test
@@ -1,10 +1,10 @@
 <?xml version="1.0" ?>
 <launch>
-  
+
   <test test-name="test_action_client" pkg="aiorospy" type="test_action_client.py" />
   <test test-name="test_action_server" pkg="aiorospy" type="test_action_server.py" />
   <test test-name="test_service_proxy" pkg="aiorospy" type="test_service_proxy.py" />
   <test test-name="test_service" pkg="aiorospy" type="test_service.py" />
   <test test-name="test_subscriber" pkg="aiorospy" type="test_subscriber.py" />
-  
+
 </launch>

--- a/aiorospy/tests/test_service.py
+++ b/aiorospy/tests/test_service.py
@@ -7,6 +7,7 @@ import aiounittest
 import rospy
 import rostest
 from aiorospy import AsyncService
+from aiorospy.helpers import deflector_shield
 from std_srvs.srv import SetBool, SetBoolRequest, SetBoolResponse
 
 
@@ -33,6 +34,7 @@ class TestServiceProxy(aiounittest.AsyncTestCase):
         self.assertEquals(True, response.success)
 
         server_task.cancel()
+        await deflector_shield(server_task)
 
     async def test_service_exception(self):
         loop = asyncio.get_running_loop()
@@ -49,7 +51,7 @@ class TestServiceProxy(aiounittest.AsyncTestCase):
             response = await loop.run_in_executor(None, self.client.call, True)
 
         with self.assertRaises(RuntimeError):
-            await server_task
+            await deflector_shield(server_task)
 
 
 if __name__ == '__main__':

--- a/aiorospy/tests/test_subscriber.py
+++ b/aiorospy/tests/test_subscriber.py
@@ -3,7 +3,6 @@ import asyncio
 import sys
 import unittest
 
-import aiostream
 import aiounittest
 import rospy
 import rostest

--- a/aiorospy/tests/test_subscriber.py
+++ b/aiorospy/tests/test_subscriber.py
@@ -8,6 +8,7 @@ import aiounittest
 import rospy
 import rostest
 from aiorospy import AsyncSubscriber
+from aiorospy.helpers import deflector_shield
 from std_msgs.msg import Int16
 
 
@@ -43,7 +44,7 @@ class TestSubscriber(aiounittest.AsyncTestCase):
         self.assertEqual(to_send, received)
 
         pub_task.cancel()
-        await pub_task
+        await deflector_shield(pub_task)
 
     @unittest.skip("Test is flaky, hard to be deterministic across three buffers.")
     async def test_subscriber_small_queue(self):
@@ -75,7 +76,7 @@ class TestSubscriber(aiounittest.AsyncTestCase):
         self.assertTrue(len(received) < message_quantity)
 
         pub_task.cancel()
-        await pub_task
+        await deflector_shield(pub_task)
 
 
 if __name__ == '__main__':

--- a/aiorospy_examples/scripts/simple_actions
+++ b/aiorospy_examples/scripts/simple_actions
@@ -10,22 +10,11 @@ from actionlib.msg import TestAction, TestGoal, TestResult
 class SimpleActionDemo:
 
     def __init__(self):
-        self.server = aiorospy.AsyncActionServer('async_simple_action', TestAction, self.handle_action)
+        self.server = aiorospy.AsyncActionServer('async_simple_action', TestAction, self.handle_action, simple=True)
         self.client = aiorospy.AsyncActionClient('async_simple_action', TestAction)
-        self.current_goal_handle = None
 
     async def handle_action(self, goal_handle):
         goal_id = goal_handle.get_goal_id().id.split('-')[1]
-        old_goal_handle = self.current_goal_handle
-        self.current_goal_handle = goal_handle
-        try:
-            if old_goal_handle:
-                await asyncio.shield(self.server.cancel(old_goal_handle))
-
-        except asyncio.CancelledError:
-            print(f"Server: Interrupted before starting task {goal_id}")
-            goal_handle.set_rejected()
-            raise
 
         try:
             delay = goal_handle.get_goal().goal / 1000


### PR DESCRIPTION
Implement simple action server - this was harder than it should have been. Turns out there was an unpleasant bug in server.cancel(goal_handle) to begin with, that's been patched with the 'deflector_shield' helper.

One point up for debate - this is slightly different from the base SimpleActionServer. We still keep the ability to accept/reject goals, however all prior goals are cancelled regardless.

PR for locomotor_shim incoming