### PR TITLE
python3.6 support

### DIFF
--- a/aiorospy/CMakeLists.txt
+++ b/aiorospy/CMakeLists.txt
@@ -16,7 +16,7 @@ if(CATKIN_ENABLE_TESTING)
   find_package(catkin REQUIRED COMPONENTS catkin_virtualenv roslint rostest)
 
   catkin_generate_virtualenv(
-    PYTHON_VERSION 3.7
+    PYTHON_VERSION 3.6
   )
   set(python_test_scripts
     tests/test_action_client.py

--- a/aiorospy/package.xml
+++ b/aiorospy/package.xml
@@ -18,7 +18,7 @@
   <exec_depend>rospy</exec_depend>
   
   <test_depend>catkin_virtualenv</test_depend>
-  <test_depend>python3.7</test_depend>
+  <test_depend>python3.6</test_depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
   

--- a/aiorospy/requirements.txt
+++ b/aiorospy/requirements.txt
@@ -1,2 +1,3 @@
 aiounittest==1.2.1
 janus==0.4.0
+async_generator==1.10

--- a/aiorospy/src/aiorospy/action.py
+++ b/aiorospy/src/aiorospy/action.py
@@ -32,11 +32,11 @@ class _AsyncGoalHandle:
         """ Async generator providing feedback from the goal. The generator terminates when the goal
         is done.
         """
-        terminal_status = asyncio.create_task(self._done_event.wait())
+        terminal_status = asyncio.ensure_future(self._done_event.wait())
         try:
             while True:
                 try:
-                    new_feedback = asyncio.create_task(self._feedback_queue.async_q.get())
+                    new_feedback = asyncio.ensure_future(self._feedback_queue.async_q.get())
                     done, pending = await asyncio.wait(
                         {terminal_status, new_feedback},
                         return_when=asyncio.FIRST_COMPLETED,
@@ -250,7 +250,7 @@ class AsyncActionServer:
         """ Process incoming goals by spinning off a new asynchronous task to handle the callback.
         """
         goal_id = goal_handle.get_goal_id().id
-        task = asyncio.create_task(self._wrapper_coro(
+        task = asyncio.ensure_future(self._wrapper_coro(
             goal_id=goal_id,
             goal_handle=goal_handle,
             preempt_tasks={**self.tasks} if self.simple else {},

--- a/aiorospy/src/aiorospy/helpers.py
+++ b/aiorospy/src/aiorospy/helpers.py
@@ -1,6 +1,5 @@
 import asyncio
 import concurrent.futures
-import contextlib
 import functools
 import logging
 import subprocess
@@ -8,6 +7,7 @@ import time
 
 import janus
 import rospy
+from async_generator import asynccontextmanager
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +104,7 @@ def iscoroutinefunction_or_partial(fxn):
 async def do_while(awaitable, period, do, *args, **kwargs):
     """ Convience function to periodically 'do' a callable while an awaitable is in progress. """
     if period is not None:
-        task = asyncio.create_task(awaitable)
+        task = asyncio.ensure_future(awaitable)
         while True:
             try:
                 result = await asyncio.wait_for(
@@ -161,7 +161,7 @@ async def deflector_shield(task):
         return None  # supress propagating an 'inner' cancel
 
 
-@contextlib.asynccontextmanager
+@asynccontextmanager
 async def subprocess_run(command, sudo=False, capture_output=False, terminate_timeout=5.0, *args, **kwargs):
     """ Higher level wrapper for asyncio.subprocess_exec, to run a command asynchronously.
     :param command: Command to be executed in a list. e.g. ['ls', '-l']

--- a/aiorospy/tests/test_action_client.py
+++ b/aiorospy/tests/test_action_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3.6
 import asyncio
 import sys
 import unittest
@@ -37,7 +37,7 @@ class TestActionClient(aiounittest.AsyncTestCase):
 
         server = self.create_server("test_success_result", goal_cb)
         client = AsyncActionClient(server.ns, TestAction)
-        client_task = asyncio.create_task(client.start())
+        client_task = asyncio.ensure_future(client.start())
 
         await client.wait_for_server()
         goal_handle = await client.send_goal(TestGoal(1))
@@ -65,7 +65,7 @@ class TestActionClient(aiounittest.AsyncTestCase):
 
         server = self.create_server("test_wait_for_result", goal_cb)
         client = AsyncActionClient(server.ns, TestAction)
-        client_task = asyncio.create_task(client.start())
+        client_task = asyncio.ensure_future(client.start())
 
         await client.wait_for_server()
         goal_handle = await client.send_goal(TestGoal(1))
@@ -93,7 +93,7 @@ class TestActionClient(aiounittest.AsyncTestCase):
 
         server = self.create_server("test_cancel", goal_cb, cancel_cb)
         client = AsyncActionClient(server.ns, TestAction)
-        client_task = asyncio.create_task(client.start())
+        client_task = asyncio.ensure_future(client.start())
 
         await client.wait_for_server()
         goal_handle = await client.send_goal(TestGoal())
@@ -111,7 +111,7 @@ class TestActionClient(aiounittest.AsyncTestCase):
 
         server = self.create_server("test_ensure", goal_cb, auto_start=False)
         client = AsyncActionClient(server.ns, TestAction)
-        client_task = asyncio.create_task(client.start())
+        client_task = asyncio.ensure_future(client.start())
 
         with self.assertRaises(asyncio.TimeoutError):
             await asyncio.wait_for(client.ensure_goal(TestGoal(), resend_timeout=0.1), timeout=1)

--- a/aiorospy/tests/test_action_server.py
+++ b/aiorospy/tests/test_action_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3.6
 import asyncio
 import sys
 import unittest
@@ -37,7 +37,7 @@ class TestActionServer(aiounittest.AsyncTestCase):
 
         client = SyncActionClient("test_goal_succeeded", TestAction)
         server = AsyncActionServer(client.ns, TestAction, coro=goal_coro)
-        server_task = asyncio.create_task(server.start())
+        server_task = asyncio.ensure_future(server.start())
 
         await asyncio.get_event_loop().run_in_executor(None, client.wait_for_server)
         goal_handle = client.send_goal(TestGoal(magic_value))
@@ -62,7 +62,7 @@ class TestActionServer(aiounittest.AsyncTestCase):
 
         client = SyncActionClient("test_goal_canceled_from_client", TestAction)
         server = AsyncActionServer(client.ns, TestAction, coro=goal_coro)
-        server_task = asyncio.create_task(server.start())
+        server_task = asyncio.ensure_future(server.start())
 
         await asyncio.get_event_loop().run_in_executor(None, client.wait_for_server)
         goal_handle = client.send_goal(TestGoal())
@@ -92,7 +92,7 @@ class TestActionServer(aiounittest.AsyncTestCase):
 
         client = SyncActionClient("test_goal_canceled_from_server", TestAction)
         server = AsyncActionServer(client.ns, TestAction, coro=goal_coro)
-        server_task = asyncio.create_task(server.start())
+        server_task = asyncio.ensure_future(server.start())
 
         await asyncio.get_event_loop().run_in_executor(None, client.wait_for_server)
         goal_handle = client.send_goal(TestGoal())
@@ -115,7 +115,7 @@ class TestActionServer(aiounittest.AsyncTestCase):
 
         client = SyncActionClient("test_goal_aborted", TestAction)
         server = AsyncActionServer(client.ns, TestAction, coro=goal_coro)
-        server_task = asyncio.create_task(server.start())
+        server_task = asyncio.ensure_future(server.start())
 
         await asyncio.get_event_loop().run_in_executor(None, client.wait_for_server)
         goal_handle = client.send_goal(TestGoal())
@@ -149,7 +149,7 @@ class TestActionServer(aiounittest.AsyncTestCase):
 
         client = SyncActionClient("test_server_simple", TestAction)
         server = AsyncActionServer(client.ns, TestAction, coro=goal_coro, simple=True)
-        server_task = asyncio.create_task(server.start())
+        server_task = asyncio.ensure_future(server.start())
 
         await asyncio.get_event_loop().run_in_executor(None, client.wait_for_server)
 

--- a/aiorospy/tests/test_service.py
+++ b/aiorospy/tests/test_service.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3.6
 import asyncio
 import sys
 import unittest
@@ -21,13 +21,13 @@ class TestServiceProxy(aiounittest.AsyncTestCase):
         self.client = rospy.ServiceProxy("test_service", SetBool)
 
     async def test_service_normal(self):
-        loop = asyncio.get_running_loop()
+        loop = asyncio.get_event_loop()
 
         async def callback(req):
             return SetBoolResponse(success=req.data)
 
         self.server = AsyncService("test_service", SetBool, callback, loop)
-        server_task = asyncio.create_task(self.server.start())
+        server_task = asyncio.ensure_future(self.server.start())
 
         await loop.run_in_executor(None, self.client.wait_for_service)
         response = await loop.run_in_executor(None, self.client.call, True)
@@ -37,13 +37,13 @@ class TestServiceProxy(aiounittest.AsyncTestCase):
         await deflector_shield(server_task)
 
     async def test_service_exception(self):
-        loop = asyncio.get_running_loop()
+        loop = asyncio.get_event_loop()
 
         async def callback(req):
             raise RuntimeError()
 
         self.server = AsyncService("test_service", SetBool, callback, loop)
-        server_task = asyncio.create_task(self.server.start())
+        server_task = asyncio.ensure_future(self.server.start())
 
         await loop.run_in_executor(None, self.client.wait_for_service)
 

--- a/aiorospy/tests/test_service_proxy.py
+++ b/aiorospy/tests/test_service_proxy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3.6
 import asyncio
 import sys
 import unittest

--- a/aiorospy/tests/test_subscriber.py
+++ b/aiorospy/tests/test_subscriber.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3.6
 import asyncio
 import sys
 import unittest
@@ -29,7 +29,7 @@ class TestSubscriber(aiounittest.AsyncTestCase):
             for msg in to_send:
                 pub.publish(msg)
 
-        pub_task = asyncio.create_task(publish())
+        pub_task = asyncio.ensure_future(publish())
 
         received = []
 
@@ -60,7 +60,7 @@ class TestSubscriber(aiounittest.AsyncTestCase):
             for msg in to_send:
                 pub.publish(msg)
 
-        pub_task = asyncio.create_task(publish())
+        pub_task = asyncio.ensure_future(publish())
 
         received = []
 

--- a/aiorospy_examples/CMakeLists.txt
+++ b/aiorospy_examples/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package()
 
 catkin_generate_virtualenv(
-  PYTHON_VERSION 3.7
+  PYTHON_VERSION 3.6
 )
 
 install(FILES requirements.txt

--- a/aiorospy_examples/package.xml
+++ b/aiorospy_examples/package.xml
@@ -15,7 +15,7 @@
   
   <build_depend>catkin_virtualenv</build_depend>
   
-  <depend>python3.7</depend>
+  <depend>python3.6</depend>
   
   <depend>aiorospy</depend>
   

--- a/aiorospy_examples/scripts/actions
+++ b/aiorospy_examples/scripts/actions
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3.6
 import asyncio
 import random
 

--- a/aiorospy_examples/scripts/aiorospy_telephone
+++ b/aiorospy_examples/scripts/aiorospy_telephone
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3.6
 import asyncio
 import logging
 

--- a/aiorospy_examples/scripts/services
+++ b/aiorospy_examples/scripts/services
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3.6
 import asyncio
 import random
 

--- a/aiorospy_examples/scripts/simple_actions
+++ b/aiorospy_examples/scripts/simple_actions
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3.6
 import asyncio
 import random
 

--- a/aiorospy_examples/scripts/topics
+++ b/aiorospy_examples/scripts/topics
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3.6
 import asyncio
 
 import aiorospy


### PR DESCRIPTION
Hello,

we had the requirement to use aiorospy in melodic so we followed the direction mentioned in #15 to make aiorospy work with python3.6 instead of depending on python3.7.

I am unsure which branch in this repo is actually used. `master` or `release/19.7` ? 

anyhow we based the python3.6 compat branch on `master`.

