### PR TITLE
Wait for a service longer

### DIFF
--- a/aiorospy/src/aiorospy/service.py
+++ b/aiorospy/src/aiorospy/service.py
@@ -27,8 +27,9 @@ class AsyncServiceProxy:
     async def _wait_for_service(self):
         while True:
             try:
-                # Use a small timeout so the execution can be cancelled if necessary
-                return await self._loop.run_in_executor(None, self._srv_proxy.wait_for_service, 0.1)
+                # ~Use a small timeout so the execution can be cancelled if necessary~
+                # Use a large timeout, otherwise wait_for_service will never succeed in bad networking environments.
+                return await self._loop.run_in_executor(None, self._srv_proxy.wait_for_service, 10.0)
             except rospy.ROSException:
                 continue
 
@@ -46,7 +47,7 @@ class AsyncServiceProxy:
         """ Send a request to a ROS service, retrying if comms failure is detected. """
         log_period = kwargs.pop('log_period', None)
         while True:
-            # await self.wait_for_service(log_period)
+            await self.wait_for_service(log_period)
             try:
                 return await self.send(*args, **kwargs)
             except (rospy.ServiceException, AttributeError, rospy.exceptions.ROSException,

--- a/aiorospy/src/aiorospy/service.py
+++ b/aiorospy/src/aiorospy/service.py
@@ -46,7 +46,7 @@ class AsyncServiceProxy:
         """ Send a request to a ROS service, retrying if comms failure is detected. """
         log_period = kwargs.pop('log_period', None)
         while True:
-            await self.wait_for_service(log_period)
+            # await self.wait_for_service(log_period)
             try:
                 return await self.send(*args, **kwargs)
             except (rospy.ServiceException, AttributeError, rospy.exceptions.ROSException,


### PR DESCRIPTION
A 100ms timeout for wait_for_service was an attempt to make it 'pre-emptible' by asyncio, however this would have really unpleasant side-effects in bad networking situations.

Requires backport to 20.1