### PR TITLE
replace python_interpreter 3.6 with 3

### DIFF
--- a/aiorospy/CMakeLists.txt
+++ b/aiorospy/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(aiorospy)
 
 find_package(catkin REQUIRED COMPONENTS
@@ -17,7 +17,7 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_generate_virtualenv(
     INPUT_REQUIREMENTS requirements.in
-    PYTHON_INTERPRETER python3.6
+    PYTHON_INTERPRETER python3
   )
   set(python_test_scripts
     tests/test_action_client.py

--- a/aiorospy/package.xml
+++ b/aiorospy/package.xml
@@ -3,27 +3,27 @@
   <name>aiorospy</name>
   <version>0.1.0</version>
   <description>Asyncio wrapper around rospy I/O interfaces.</description>
-  
+
   <author email="ablakey@locusrobotics.com">Andrew Blakey</author>
   <author email="pbovbel@locusrobotics.com">Paul Bovbel</author>
-  
+
   <maintainer email="ablakey@locusrobotics.com">Andrew Blakey</maintainer>
   <maintainer email="pbovbel@locusrobotics.com">Paul Bovbel</maintainer>
-  
+
   <license>MIT</license>
-  
+
   <buildtool_depend>catkin</buildtool_depend>
-  
+
   <exec_depend>actionlib</exec_depend>
   <exec_depend>rospy</exec_depend>
-  
+
   <test_depend>catkin_virtualenv</test_depend>
-  <test_depend>python3.6</test_depend>
+  <test_depend>python3</test_depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
-  
+
   <export>
     <pip_requirements>requirements.txt</pip_requirements>
   </export>
-  
+
 </package>

--- a/aiorospy/tests/test_action_client.py
+++ b/aiorospy/tests/test_action_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 import asyncio
 import sys
 import unittest

--- a/aiorospy/tests/test_action_server.py
+++ b/aiorospy/tests/test_action_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 import asyncio
 import sys
 import unittest

--- a/aiorospy/tests/test_service.py
+++ b/aiorospy/tests/test_service.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 import asyncio
 import sys
 import unittest

--- a/aiorospy/tests/test_service_proxy.py
+++ b/aiorospy/tests/test_service_proxy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 import asyncio
 import sys
 import unittest

--- a/aiorospy/tests/test_subscriber.py
+++ b/aiorospy/tests/test_subscriber.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 import asyncio
 import sys
 import unittest

--- a/aiorospy_examples/CMakeLists.txt
+++ b/aiorospy_examples/CMakeLists.txt
@@ -9,7 +9,7 @@ catkin_package()
 
 catkin_generate_virtualenv(
   INPUT_REQUIREMENTS requirements.in
-  PYTHON_INTERPRETER python3.6
+  PYTHON_INTERPRETER python3
 )
 
 install(FILES requirements.txt

--- a/aiorospy_examples/package.xml
+++ b/aiorospy_examples/package.xml
@@ -3,30 +3,30 @@
   <name>aiorospy_examples</name>
   <version>0.1.0</version>
   <description>Example scripts using aiorospy.</description>
-  
+
   <author email="ablakey@locusrobotics.com">Andrew Blakey</author>
   <author email="pbovbel@locusrobotics.com">Paul Bovbel</author>
-  
+
   <maintainer email="ablakey@locusrobotics.com">Andrew Blakey</maintainer>
   <maintainer email="pbovbel@locusrobotics.com">Paul Bovbel</maintainer>
   <license>MIT</license>
-  
+
   <buildtool_depend>catkin</buildtool_depend>
-  
+
   <build_depend>catkin_virtualenv</build_depend>
-  
-  <depend>python3.6</depend>
-  
+
+  <depend>python3</depend>
+
   <depend>aiorospy</depend>
-  
+
   <exec_depend>rospy_tutorials</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>
-  
+
   <test_depend>roslint</test_depend>
-  
+
   <export>
     <pip_requirements>requirements.txt</pip_requirements>
   </export>
-  
+
 </package>

--- a/aiorospy_examples/scripts/actions
+++ b/aiorospy_examples/scripts/actions
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 import asyncio
 import random
 

--- a/aiorospy_examples/scripts/aiorospy_telephone
+++ b/aiorospy_examples/scripts/aiorospy_telephone
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 import asyncio
 import logging
 

--- a/aiorospy_examples/scripts/services
+++ b/aiorospy_examples/scripts/services
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 import asyncio
 import random
 

--- a/aiorospy_examples/scripts/simple_actions
+++ b/aiorospy_examples/scripts/simple_actions
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 import asyncio
 import random
 

--- a/aiorospy_examples/scripts/topics
+++ b/aiorospy_examples/scripts/topics
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 import asyncio
 
 import aiorospy


### PR DESCRIPTION
The changes from @betaboon work fine for me as well with noetic.  They can be applied on top of master.  python3 will be used instead of explicitly using python3.6.