### PR TITLE
Fix async generator dependency

### DIFF
--- a/aiorospy/requirements.txt
+++ b/aiorospy/requirements.txt
@@ -1,3 +1,3 @@
 aiounittest==1.3.1        # via -r /home/pbovbel/locus_dev/src/aiorospy/aiorospy/requirements.in
-async_generator==1.10     # via -r /home/pbovbel/locus_dev/src/aiorospy/aiorospy/requirements.in
+async-generator==1.10     # via -r /home/pbovbel/locus_dev/src/aiorospy/aiorospy/requirements.in
 janus==0.5.0              # via -r /home/pbovbel/locus_dev/src/aiorospy/aiorospy/requirements.in

--- a/aiorospy/requirements.txt
+++ b/aiorospy/requirements.txt
@@ -1,3 +1,3 @@
 aiounittest==1.3.1        # via -r /home/pbovbel/locus_dev/src/aiorospy/aiorospy/requirements.in
-async-generator==1.10     # via -r /home/pbovbel/locus_dev/src/aiorospy/aiorospy/requirements.in
+async_generator==1.10     # via -r /home/pbovbel/locus_dev/src/aiorospy/aiorospy/requirements.in
 janus==0.5.0              # via -r /home/pbovbel/locus_dev/src/aiorospy/aiorospy/requirements.in

--- a/aiorospy/src/aiorospy/helpers.py
+++ b/aiorospy/src/aiorospy/helpers.py
@@ -4,10 +4,15 @@ import functools
 import logging
 import subprocess
 import time
+import sys
 
 import janus
 import rospy
-from async_generator import asynccontextmanager
+
+if sys.version_info >= (3, 10):
+    from contextlib import asynccontextmanager
+else:
+    from async_generator import asynccontextmanager
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
It seems like asynccontextmanager is included in the standard contextlib module so we don't need the dependency on async_generator in python versions above 3.10.

In order to maintain compatibility I've kept the dependency there matching https://github.com/jupyterhub/jupyterhub/pull/4799/files