### PR TITLE
Don't use async_generator for python3.9+

### DIFF
--- a/aiorospy/src/aiorospy/helpers.py
+++ b/aiorospy/src/aiorospy/helpers.py
@@ -9,7 +9,7 @@ import sys
 import janus
 import rospy
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 9):
     from contextlib import asynccontextmanager
 else:
     from async_generator import asynccontextmanager


### PR DESCRIPTION
The `asynccontextmanager` is available in the `contextlib` library on python3.9. Tested on a robot