### PR TITLE
Use separated requirements files for each distro

### DIFF
--- a/aiorospy/CMakeLists.txt
+++ b/aiorospy/CMakeLists.txt
@@ -9,7 +9,8 @@ catkin_package()
 
 catkin_python_setup()
 
-install(FILES requirements.txt
+file(GLOB REQUIREMENTS_FILES "requirements*.txt")
+install(FILES ${REQUIREMENTS_FILES}
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
@@ -17,7 +18,6 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_generate_virtualenv(
     INPUT_REQUIREMENTS requirements.in
-    PYTHON_INTERPRETER python3
   )
   set(python_test_scripts
     tests/test_action_client.py

--- a/aiorospy/requirements-noble.txt
+++ b/aiorospy/requirements-noble.txt
@@ -1,0 +1,4 @@
+aiounittest==1.5.0        # via -r requirements.in
+async-generator==1.10     # via -r requirements.in
+janus==2.0.0              # via -r requirements.in
+wrapt==2.1.1              # via -r requirements.in, aiounittest

--- a/aiorospy/src/aiorospy/action.py
+++ b/aiorospy/src/aiorospy/action.py
@@ -93,7 +93,7 @@ class _AsyncGoalHandle:
 
     def _transition_cb(self, goal_handle):
         try:
-            future = asyncio.run_coroutine_threadsafe(self._process_transition(
+            _ = asyncio.run_coroutine_threadsafe(self._process_transition(
                 # We must use these accessors here instead of passing through goal_handle to avoid hitting deadlock
                 status=goal_handle.get_goal_status(),
                 comm_state=goal_handle.get_comm_state(),

--- a/aiorospy/src/aiorospy/helpers.py
+++ b/aiorospy/src/aiorospy/helpers.py
@@ -202,7 +202,7 @@ async def subprocess_end(process, terminate_timeout=5.0):
         try:
             await asyncio.wait_for(process.wait(), timeout=terminate_timeout)
         except asyncio.TimeoutError:
-            logger.warn(f"Process did not terminate, escalating to kill: {command}")
+            logger.warn(f"Process did not terminate, escalating to kill: {process}")
             process.kill()
             await process.wait()
 

--- a/aiorospy/tests/test_action_server.py
+++ b/aiorospy/tests/test_action_server.py
@@ -71,7 +71,7 @@ class TestActionServer(aiounittest.AsyncTestCase):
         goal_handle.cancel()
 
         await self.wait_for_status(goal_handle, GoalStatus.PREEMPTED)
-        self.assertEquals(goal_handle.get_goal_status(), GoalStatus.PREEMPTED)
+        self.assertEqual(goal_handle.get_goal_status(), GoalStatus.PREEMPTED)
 
         server_task.cancel()
         await deflector_shield(server_task)
@@ -102,7 +102,7 @@ class TestActionServer(aiounittest.AsyncTestCase):
         await server.cancel(server_goal_handle)
 
         await self.wait_for_status(goal_handle, GoalStatus.PREEMPTED)
-        self.assertEquals(goal_handle.get_goal_status(), GoalStatus.PREEMPTED)
+        self.assertEqual(goal_handle.get_goal_status(), GoalStatus.PREEMPTED)
 
         server_task.cancel()
         await deflector_shield(server_task)
@@ -120,7 +120,7 @@ class TestActionServer(aiounittest.AsyncTestCase):
         goal_handle = client.send_goal(TestGoal())
 
         await self.wait_for_status(goal_handle, GoalStatus.ABORTED)
-        self.assertEquals(goal_handle.get_goal_status(), GoalStatus.ABORTED)
+        self.assertEqual(goal_handle.get_goal_status(), GoalStatus.ABORTED)
 
         with self.assertRaises(RuntimeError):
             await deflector_shield(server_task)

--- a/aiorospy/tests/test_service.py
+++ b/aiorospy/tests/test_service.py
@@ -30,7 +30,7 @@ class TestServiceProxy(aiounittest.AsyncTestCase):
 
         await loop.run_in_executor(None, self.client.wait_for_service)
         response = await loop.run_in_executor(None, self.client.call, True)
-        self.assertEquals(True, response.success)
+        self.assertEqual(True, response.success)
 
         server_task.cancel()
         await deflector_shield(server_task)
@@ -47,7 +47,7 @@ class TestServiceProxy(aiounittest.AsyncTestCase):
         await loop.run_in_executor(None, self.client.wait_for_service)
 
         with self.assertRaises(rospy.ServiceException):
-            response = await loop.run_in_executor(None, self.client.call, True)
+            _ = await loop.run_in_executor(None, self.client.call, True)
 
         with self.assertRaises(RuntimeError):
             await deflector_shield(server_task)

--- a/aiorospy/tests/test_service_proxy.py
+++ b/aiorospy/tests/test_service_proxy.py
@@ -23,9 +23,9 @@ class TestServiceProxy(aiounittest.AsyncTestCase):
     async def test_service_proxy(self):
         client = AsyncServiceProxy("test_service", SetBool)
         response = await client.ensure(False)
-        self.assertEquals(False, response.success)
+        self.assertEqual(False, response.success)
         response = await client.ensure(data=True)
-        self.assertEquals(True, response.success)
+        self.assertEqual(True, response.success)
 
 
 if __name__ == '__main__':

--- a/aiorospy_examples/CMakeLists.txt
+++ b/aiorospy_examples/CMakeLists.txt
@@ -9,10 +9,10 @@ catkin_package()
 
 catkin_generate_virtualenv(
   INPUT_REQUIREMENTS requirements.in
-  PYTHON_INTERPRETER python3
 )
 
-install(FILES requirements.txt
+file(GLOB REQUIREMENTS_FILES "requirements*.txt")
+install(FILES ${REQUIREMENTS_FILES}
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 set(python_scripts

--- a/aiorospy_examples/CMakeLists.txt
+++ b/aiorospy_examples/CMakeLists.txt
@@ -3,6 +3,7 @@ project(aiorospy_examples)
 
 find_package(catkin REQUIRED COMPONENTS
   catkin_virtualenv
+  aiorospy
 )
 
 catkin_package()

--- a/aiorospy_examples/package.xml
+++ b/aiorospy_examples/package.xml
@@ -15,8 +15,6 @@
 
   <build_depend>catkin_virtualenv</build_depend>
 
-  <depend>python3</depend>
-
   <depend>aiorospy</depend>
 
   <exec_depend>rospy_tutorials</exec_depend>

--- a/aiorospy_examples/requirements-noble.txt
+++ b/aiorospy_examples/requirements-noble.txt
@@ -1,0 +1,11 @@
+aiohappyeyeballs==2.6.1   # via aiohttp
+aiohttp==3.13.5           # via -r requirements.in
+aiosignal==1.4.0          # via aiohttp
+async-timeout==5.0.1      # via aiohttp
+attrs==26.1.0             # via aiohttp
+frozenlist==1.8.0         # via aiohttp, aiosignal
+idna==3.11                # via yarl
+multidict==6.7.1          # via aiohttp, yarl
+propcache==0.4.1          # via aiohttp, yarl
+typing-extensions==4.15.0  # via aiosignal, multidict
+yarl==1.23.0              # via aiohttp


### PR DESCRIPTION
This makes catkin_virtualenv use the default python for each ubuntu distribution as well as use a separated requirements.txt for noble. This is so we can run this both on jammy and noble. This option was added in https://github.com/locusrobotics/catkin_virtualenv/pull/123